### PR TITLE
preserve option for transdecoder increasing complete ORFs

### DIFF
--- a/PerlLib/Longest_orf.pm
+++ b/PerlLib/Longest_orf.pm
@@ -169,13 +169,13 @@ sub capture_all_ORFs {
     if (@orfs) {
 		## set in order of decreasing length
 		@orfs = reverse sort {$a->{length} <=> $b->{length}} @orfs;
-		
 		my $longest_orf = $orfs[0];
+		my $seq = $longest_orf->{sequence};
+    my $length = length($seq);
+    my $protein = &translate_sequence($seq, 1);
+		
 		my $start = $longest_orf->{start};
 		my $stop = $longest_orf->{stop};
-		my $seq = $longest_orf->{sequence};
-		my $length = length($seq);
-		my $protein = &translate_sequence($seq, 1);
 		$self->{end5} = $start;  ## now coord is seq_based instead of array based.
 		$self->{end3} = $stop;
 		$self->{length} = $length;
@@ -185,6 +185,44 @@ sub capture_all_ORFs {
 	}
 
 	return (@orfs);
+}
+
+sub check_for_fp_5prime_partials {
+  my($self,$min_len,$orfs_ref) = @_;
+  my @orfs = @$orfs_ref;
+  print "IN fp $#orfs\n" if($SEE);
+  for(my $i = 0; $i <= $#orfs; $i++) {
+    use Data::Dumper;
+
+    next if($orfs[$i]->{type} ne '5prime_partial');
+    my $fl_start = index($orfs[$i]->{protein}, 'M');
+    next if($fl_start == -1);
+
+ 
+    my $fl_protein = substr($orfs[$i]->{protein}, $fl_start);
+    print "partial with M\nnew prot: $fl_protein\n" if($SEE);
+    print Dumper($orfs[$i]) if($SEE);
+
+    next if($i < $#orfs && length($orfs[$i+1]->{protein}) > length($fl_protein));
+    next if(length($fl_protein) < $min_len);
+ 
+    print "seq start: $orfs[$i]->{start} new start: ".($orfs[$i]->{start} + $fl_start*3)." length: $orfs[$i]->{length}\n" if($SEE);
+    $orfs[$i]->{sequence} = substr($orfs[$i]->{sequence},$fl_start*3);
+    $orfs[$i]->{length} = length($orfs[$i]->{sequence});
+    if($orfs[$i]->{orient} eq '+') {
+      $orfs[$i]->{start} = $orfs[$i]->{start} +$fl_start*3;
+    } else {
+      $orfs[$i]->{start} = $orfs[$i]->{start} -$fl_start*3;
+    }
+
+    $orfs[$i]->{protein} = $fl_protein;
+    $orfs[$i]->{type} = 'complete';
+    
+    print "passt\n" if ($SEE);
+    print Dumper($orfs[$i]) if($SEE);
+
+  }
+
 }
 
 sub orfs {
@@ -271,8 +309,31 @@ sub get_orfs {
 				if ($protein =~ /\*.*\*/) {
 				  confess "Fatal Error: Longest_orf: ORF returned which contains intervening stop(s): ($start-$stop, $direction\nProtein:\n$protein\nOf Nucleotide Seq:\n$seq\n";
 				}
+
+        my $got_start = 0;
+        my $got_stop = 0;
+        if ($protein =~ /^M/) {
+            $got_start = 1;
+        } 
+        if ($protein =~ /\*$/) {
+            $got_stop = 1;
+        }
+        
+        my $prot_type = "";
+        if ($got_start && $got_stop) {
+            $prot_type = "complete";
+        } elsif ($got_start) {
+            $prot_type = "3prime_partial";
+        } elsif ($got_stop) {
+            $prot_type = "5prime_partial";
+        } else {
+            $prot_type = "internal";
+        }
+        print "Setting type $prot_type\n" if($SEE);
+
 				my $orf = { sequence => $orfSeq,
 							protein => $protein,
+              type => $prot_type,
 							start=>$start,
 							stop=>$stop,
 							length=>length($orfSeq),

--- a/PerlLib/Longest_orf.pm
+++ b/PerlLib/Longest_orf.pm
@@ -188,9 +188,10 @@ sub capture_all_ORFs {
 }
 
 sub check_for_fp_5prime_partials {
-  my($self,$min_len,$orfs_ref) = @_;
+  my($self,$min_len,$orfs_ref,$pct_cutoff) = @_;
   my @orfs = @$orfs_ref;
   print "IN fp $#orfs\n" if($SEE);
+  $pct_cutoff /= 100;
   for(my $i = 0; $i <= $#orfs; $i++) {
     use Data::Dumper;
 
@@ -203,8 +204,9 @@ sub check_for_fp_5prime_partials {
     print "partial with M\nnew prot: $fl_protein\n" if($SEE);
     print Dumper($orfs[$i]) if($SEE);
 
-    next if($i < $#orfs && length($orfs[$i+1]->{protein}) > length($fl_protein));
     next if(length($fl_protein) < $min_len);
+    next if(length($fl_protein) < $pct_cutoff*length($orfs[$i]->{protein}));
+    next if($i < $#orfs && length($orfs[$i+1]->{protein}) > length($fl_protein));
  
     print "seq start: $orfs[$i]->{start} new start: ".($orfs[$i]->{start} + $fl_start*3)." length: $orfs[$i]->{length}\n" if($SEE);
     $orfs[$i]->{sequence} = substr($orfs[$i]->{sequence},$fl_start*3);
@@ -218,9 +220,7 @@ sub check_for_fp_5prime_partials {
     $orfs[$i]->{protein} = $fl_protein;
     $orfs[$i]->{type} = 'complete';
     
-    print "passt\n" if ($SEE);
     print Dumper($orfs[$i]) if($SEE);
-
   }
 
 }

--- a/TransDecoder.LongOrfs
+++ b/TransDecoder.LongOrfs
@@ -22,7 +22,7 @@ Optional:
 
  -S                                     strand-specific (only analyzes top strand)
 
- -p                                     preserve full length orfs, removing potential FP partials
+ -p <int>                               shorten potential 5' partials if they are this percentage of the original protein or longer.
 
 =head1 Genetic Codes
 
@@ -74,7 +74,7 @@ my ($transcripts_file);
 
 my $genetic_code='universal';
 
-my $preserve_full_lengths = 0;
+my $preserve_full_lengths = undef;
 
 my $TOP_STRAND_ONLY = 0;
 
@@ -93,7 +93,7 @@ my $MPI_DEBUG = 1;
              'h' => \$help,
              'v' => \$verbose,
              'S' => \$TOP_STRAND_ONLY, 
-             'p' => \$preserve_full_lengths
+             'p=i' => \$preserve_full_lengths
              );
 
 
@@ -176,7 +176,8 @@ main: {
 		
 		@orf_structs = reverse sort {$a->{length}<=>$b->{length}} @orf_structs;
     print "checking for fp in $acc \n" if ($SEE);
-    $longest_orf_finder->check_for_fp_5prime_partials($MIN_PROT_LENGTH,\@orf_structs) if($preserve_full_lengths);
+    $longest_orf_finder->check_for_fp_5prime_partials($MIN_PROT_LENGTH,\@orf_structs,$preserve_full_lengths) 
+       if(defined($preserve_full_lengths));
 		
         while (@orf_structs) {
             my $orf = shift @orf_structs;

--- a/TransDecoder.LongOrfs
+++ b/TransDecoder.LongOrfs
@@ -22,6 +22,8 @@ Optional:
 
  -S                                     strand-specific (only analyzes top strand)
 
+ -p                                     preserve full length orfs, removing potential FP partials
+
 =head1 Genetic Codes
 
 See L<http://golgi.harvard.edu/biolinks/gencode.html>. These are currently supported:
@@ -72,6 +74,8 @@ my ($transcripts_file);
 
 my $genetic_code='universal';
 
+my $preserve_full_lengths = 0;
+
 my $TOP_STRAND_ONLY = 0;
 
 my $help;
@@ -89,6 +93,7 @@ my $MPI_DEBUG = 1;
              'h' => \$help,
              'v' => \$verbose,
              'S' => \$TOP_STRAND_ONLY, 
+             'p' => \$preserve_full_lengths
              );
 
 
@@ -170,6 +175,8 @@ main: {
 		my @orf_structs = $longest_orf_finder->capture_all_ORFs($sequence);
 		
 		@orf_structs = reverse sort {$a->{length}<=>$b->{length}} @orf_structs;
+    print "checking for fp in $acc \n" if ($SEE);
+    $longest_orf_finder->check_for_fp_5prime_partials($MIN_PROT_LENGTH,\@orf_structs) if($preserve_full_lengths);
 		
         while (@orf_structs) {
             my $orf = shift @orf_structs;
@@ -200,6 +207,8 @@ main: {
             if ($start < 1) {
                 $start += 3;
             }
+
+            print "Candidate (len $length): ".Dumper($orf) if($SEE);
             
                         
             if ($length < $MIN_PROT_LENGTH) { next; }
@@ -210,6 +219,10 @@ main: {
             my $gene_obj = new Gene_obj();
             
 
+            print "dumping coords for $acc $start $stop\n" if($SEE);
+            print Dumper(%$cds_coords_href) if($SEE);
+            print Dumper(%$exon_coords_href) if($SEE);
+            
             $gene_obj->populate_gene_object($cds_coords_href, $exon_coords_href);
             $gene_obj->{asmbl_id} = $acc;
             


### PR DESCRIPTION
This patch reduces the number of 5' partials while attempting to keep the ORFs long. 

Per our email this has the following changes to the algorithm when using the "-p" option:

- Do the predictions as always, with the trick of calling the first three bases as potential starts even though there is no start codon present, necessarily.
- Sort the orfs returned by capture_all_orfs. (As always)
- If the “preserve” option is selected, look through the 5’ partial orfs.
-   Look for the first in frame start, and use that as the potential new orf.
-   If that orf is not shorter than the next shortest orf overall, and not shorter than the minimum allowed orf, then replace that orf with a new orf.*

