### PR TITLE
Make output reproducible.

### DIFF
--- a/util/cufflinks_gtf_to_bed.pl
+++ b/util/cufflinks_gtf_to_bed.pl
@@ -68,11 +68,11 @@ main: {
 
 		my $genes_href = $genome_trans_to_coords{$scaff};
 
-		foreach my $gene_id (keys %$genes_href) {
+		foreach my $gene_id (sort keys %$genes_href) {
 
 			my $trans_href = $genes_href->{$gene_id};
 
-			foreach my $trans_id (keys %$trans_href) {
+			foreach my $trans_id (sort keys %$trans_href) {
 
 				my $coords_href = $trans_href->{$trans_id};
 


### PR DESCRIPTION
Hello,

Debian redistributes TransDecoder in its Debian Med project, and we aim at building "reproducible" binary packages, see <https://wiki.debian.org/ReproducibleBuilds> for details.

To make TransDecoder's `cufflinks_gtf_to_bed.pl` script produce reproducible output, we propose the following pull request.

Happy new year !

-- 
Charles Plessy
Debian Med packaging team