### PR TITLE
Make the sample data reproducible

### DIFF
--- a/sample_data/cufflinks_example/runMe.sh
+++ b/sample_data/cufflinks_example/runMe.sh
@@ -25,7 +25,7 @@ fi
 ../../util/cufflinks_gtf_to_alignment_gff3.pl transcripts.gtf > transcripts.gff3
 
 ## generate transcripts fasta file
-../../util/cufflinks_gtf_genome_to_cdna_fasta.pl transcripts.gtf test.genome.fasta > transcripts.fasta 
+PERL_HASH_SEED=0 ../../util/cufflinks_gtf_genome_to_cdna_fasta.pl transcripts.gtf test.genome.fasta > transcripts.fasta 
 
 ## Extract the long ORFs
 ../../TransDecoder.LongOrfs -t transcripts.fasta


### PR DESCRIPTION
Set a fixed hash seed for Perl before generating sample_data/transcripts.fasta
 to get reproducible results
Author: Eduard Sanou <dhole@openmailbox.org>
From https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=822268